### PR TITLE
add option to specify programs folder for running off of built meteor project

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,6 +85,11 @@ new MeteorImportsPlugin({
 })
 ```
 
+#### config.meteorProgramsFolder
+
+(Overrides `config.meteorFolder`) the path to the `programs` folder within your `meteor` folder or the result of
+`meteor build --directory`.
+
 #### config.DDP_DEFAULT_CONNECTION_URL
 
 If you are using a Meteor server, point `DDP_DEFAULT_CONNECTION_URL` to your server url. If you are developing in local, start your Meteor server and Webpack-dev-server in different ports.

--- a/index.js
+++ b/index.js
@@ -23,10 +23,12 @@ MeteorImportsPlugin.prototype.apply = function(compiler) {
     }
 
     // Create path for internal build of the meteor packages.
-    var meteorBuild = path.join(
-      params.normalModuleFactory.context, self.config.meteorFolder,
-      '.meteor', 'local', 'build', 'programs', 'web.browser'
-    );
+    var meteorBuild = self.config.meteorProgramsFolder
+      ? path.resolve(params.normalModuleFactory.context, self.config.meteorProgramsFolder, 'web.browser')
+      : path.resolve(
+        params.normalModuleFactory.context, self.config.meteorFolder,
+        '.meteor', 'local', 'build', 'programs', 'web.browser'
+      );
 
     // Create path for plugin node moduels directory.
     var meteorNodeModules = path.join(__dirname, 'node_modules');


### PR DESCRIPTION
I changed crater to always run off the output of `meteor build --directory` instead of the development folder.  This change adds a `meteorProgramsFolder` option that overrides `meteorFolder` so that I can make the plugin use `build/meteor/bundle/programs` instead of `meteor/.meteor/local/build/programs`.
