### PR TITLE
exclude non-js manifest files from being imported

### DIFF
--- a/meteor-imports.js
+++ b/meteor-imports.js
@@ -17,7 +17,7 @@ var excluded = new RegExp(config.exclude
 
 // Require the Meteor packages.
 manifest.forEach(function(pckge){
-  if (!excluded.test(pckge.path))
+  if (pckge.type === 'js' && !excluded.test(pckge.path))
     req('./' + pckge.path.replace('packages/', ''));
 });
 


### PR DESCRIPTION
This came up when I tried some angular packages and got a lot off ```.d.ts``` files along with some ```.scss``` files. Potentially the sass files could be imported, but as of now it doesn't work anyhow. This makes it not break