### PR TITLE
pin json-string-loader to 1.0.0 for now

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "exports-loader": "^0.6.3",
     "imports-loader": "^0.6.5",
     "json-loader": "^0.5.4",
-    "json-string-loader": "^1.0.0"
+    "json-string-loader": "1.0.0"
   },
   "devDependencies": {
     "eslint": "^3.7.0"


### PR DESCRIPTION
`json-string-loader@1.1.0` is causing problems for some reason (see https://github.com/jcoreio/crater/issues/113)