### PR TITLE
Add -loader suffixes

### DIFF
--- a/index.js
+++ b/index.js
@@ -118,7 +118,7 @@ MeteorImportsPlugin.prototype.apply = function(compiler) {
       {
         meteorImports: true,
         test: new RegExp('.meteor/local/build/programs/web.browser/packages'),
-        loader: 'imports?this=>window',
+        loader: 'imports-loader?this=>window',
       },
       {
         meteorImports: true,
@@ -139,7 +139,7 @@ MeteorImportsPlugin.prototype.apply = function(compiler) {
         extraRules.push({
           meteorImports: true,
           test: new RegExp('.meteor/local/build/programs/web.browser/' + pckge.path),
-          loader: 'exports?Package["' + packageName + '"]',
+          loader: 'exports-loader?Package["' + packageName + '"]',
         })
       }
     });


### PR DESCRIPTION
Webpack now requires full loader name with `-loader` suffix